### PR TITLE
Enhancing PR#43.

### DIFF
--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -25,7 +25,8 @@ from bless.config.bless_config import BlessConfig, \
     KMSAUTH_USEKMSAUTH_OPTION, \
     KMSAUTH_SERVICE_ID_OPTION, \
     TEST_USER_OPTION, \
-    CERTIFICATE_EXTENSIONS_OPTION
+    CERTIFICATE_EXTENSIONS_OPTION, \
+    REMOTE_USERNAMES_VALIDATION_OPTION
 from bless.request.bless_request import BlessSchema
 from bless.ssh.certificate_authorities.ssh_certificate_authority_factory import \
     get_ssh_certificate_authority
@@ -75,7 +76,9 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
 
     # Process cert request
     schema = BlessSchema(strict=True)
-    schema.context['username_validation'] = config.get(BLESS_OPTIONS_SECTION, USERNAME_VALIDATION_OPTION)
+    schema.context[USERNAME_VALIDATION_OPTION] = config.get(BLESS_OPTIONS_SECTION, USERNAME_VALIDATION_OPTION)
+    schema.context[REMOTE_USERNAMES_VALIDATION_OPTION] = config.get(BLESS_OPTIONS_SECTION,
+                                                                    REMOTE_USERNAMES_VALIDATION_OPTION)
 
     try:
         request = schema.load(event).data
@@ -117,8 +120,7 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
     # cert values determined only by lambda and its configs
     current_time = int(time.time())
     test_user = config.get(BLESS_OPTIONS_SECTION, TEST_USER_OPTION)
-    if (test_user and (request.bastion_user == test_user or
-            request.remote_usernames == test_user)):
+    if test_user and (request.bastion_user == test_user or request.remote_usernames == test_user):
         # This is a test call, the lambda will issue an invalid
         # certificate where valid_before < valid_after
         valid_before = current_time

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -51,6 +51,9 @@ KMSAUTH_SERVICE_ID_DEFAULT = None
 USERNAME_VALIDATION_OPTION = 'username_validation'
 USERNAME_VALIDATION_DEFAULT = 'useradd'
 
+REMOTE_USERNAMES_VALIDATION_OPTION = 'remote_usernames_validation'
+REMOTE_USERNAMES_VALIDATION_DEFAULT = 'principal'
+
 
 class BlessConfig(ConfigParser.RawConfigParser, object):
     def __init__(self, aws_region, config_file):
@@ -76,6 +79,7 @@ class BlessConfig(ConfigParser.RawConfigParser, object):
                     KMSAUTH_USEKMSAUTH_OPTION: KMSAUTH_USEKMSAUTH_DEFAULT,
                     CERTIFICATE_EXTENSIONS_OPTION: CERTIFICATE_EXTENSIONS_DEFAULT,
                     USERNAME_VALIDATION_OPTION: USERNAME_VALIDATION_DEFAULT,
+                    REMOTE_USERNAMES_VALIDATION_OPTION: REMOTE_USERNAMES_VALIDATION_DEFAULT
                     }
         ConfigParser.RawConfigParser.__init__(self, defaults=defaults)
         self.read(config_file)

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -11,6 +11,11 @@ random_seed_bytes = 256
 logging_level = INFO
 # Comma separated list of the SSH Certificate extensions to include. Not specifying this uses the ssh-keygen defaults:
 # certificate_extensions = permit-X11-forwarding,permit-agent-forwarding,permit-port-forwarding,permit-pty,permit-user-rc
+# Username validation options are described in bless_request.py:USERNAME_VALIDATION_OPTIONS
+# Configure how bastion_user names are validated.
+# username_validation = useradd
+# Configure how remote_usernames names are validated.
+# remote_usernames_validation = principal
 
 # These values are all required to be modified for deployment
 [Bless CA]

--- a/bless/request/bless_request.py
+++ b/bless/request/bless_request.py
@@ -3,11 +3,16 @@
     :copyright: (c) 2016 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 """
-from enum import Enum
 import re
 
 import ipaddress
+from enum import Enum
 from marshmallow import Schema, fields, post_load, ValidationError, validates_schema
+from marshmallow import validates
+from marshmallow.validate import Email
+
+from bless.config.bless_config import USERNAME_VALIDATION_OPTION, REMOTE_USERNAMES_VALIDATION_OPTION, \
+    USERNAME_VALIDATION_DEFAULT, REMOTE_USERNAMES_VALIDATION_DEFAULT
 
 # man 8 useradd
 USERNAME_PATTERN = re.compile('[a-z_][a-z0-9_-]*[$]?\Z')
@@ -21,12 +26,16 @@ USERNAME_PATTERN = re.compile('[a-z_][a-z0-9_-]*[$]?\Z')
 USERNAME_PATTERN_DEBIAN = re.compile('\A[^-+~][^:,\s]*\Z')
 
 # It appears that most printable ascii is valid, excluding whitespace, #, and commas.
-# There doesn't seem to be any practical size limits of a principal (> 4096B allowed).
+# There doesn't seem to be any practical size limits of an SSH Certificate Principal (> 4096B allowed).
 PRINCIPAL_PATTERN = re.compile(r'[\d\w!"$%&\'()*+\-./:;<=>?@\[\\\]\^`{|}~]+\Z')
 VALID_SSH_RSA_PUBLIC_KEY_HEADER = "ssh-rsa AAAAB3NzaC1yc2"
 
 USERNAME_VALIDATION_OPTIONS = Enum('UserNameValidationOptions',
-                                   'useradd debian relaxed disabled')
+                                   'useradd '  # Allowable usernames per 'man 8 useradd'
+                                   'debian '  # Allowable usernames on debian systems.
+                                   'email '  # username is a valid email address.
+                                   'principal '  # SSH Certificate Principal.  See 'man 5 sshd_con#  fig'.
+                                   'disabled')  # no additional validation of the string.
 
 
 def validate_ips(ips):
@@ -40,14 +49,18 @@ def validate_ips(ips):
 def validate_user(user, username_validation):
     if username_validation == USERNAME_VALIDATION_OPTIONS.disabled:
         return
-    if len(user) > 32:
+    elif username_validation == USERNAME_VALIDATION_OPTIONS.email:
+        Email('Invalid email address.').__call__(user)
+    elif username_validation == USERNAME_VALIDATION_OPTIONS.principal:
+        _validate_principal(user)
+    elif len(user) > 32:
         raise ValidationError('Username is too long.')
-    if username_validation == USERNAME_VALIDATION_OPTIONS.relaxed:
-        return
-    if username_validation == USERNAME_VALIDATION_OPTIONS.debian:
+    elif username_validation == USERNAME_VALIDATION_OPTIONS.useradd:
+        _validate_user_useradd(user)
+    elif username_validation == USERNAME_VALIDATION_OPTIONS.debian:
         _validate_user_debian(user)
     else:
-        _validate_user_useradd(user)
+        raise ValidationError('Invalid username validator.')
 
 
 def _validate_user_useradd(user):
@@ -60,10 +73,9 @@ def _validate_user_debian(user):
         raise ValidationError('Username contains invalid characters.')
 
 
-def validate_principals(principals):
-    for principal in principals.split(','):
-        if PRINCIPAL_PATTERN.match(principal) is None:
-            raise ValidationError('Principal contains invalid characters.')
+def _validate_principal(principal):
+    if PRINCIPAL_PATTERN.match(principal) is None:
+        raise ValidationError('Principal contains invalid characters.')
 
 
 def validate_ssh_public_key(public_key):
@@ -80,7 +92,7 @@ class BlessSchema(Schema):
     bastion_user_ip = fields.Str(validate=validate_ips, required=True)
     command = fields.Str(required=True)
     public_key_to_sign = fields.Str(validate=validate_ssh_public_key, required=True)
-    remote_usernames = fields.Str(validate=validate_principals, required=True)
+    remote_usernames = fields.Str(required=True)
     kmsauth_token = fields.Str(required=False)
 
     @validates_schema(pass_original=True)
@@ -89,14 +101,26 @@ class BlessSchema(Schema):
         if unknown:
             raise ValidationError('Unknown field', unknown)
 
-    @validates_schema
-    def validate_user(self, data):
-        username_validation = USERNAME_VALIDATION_OPTIONS[self.context['username_validation']]
-        validate_user(data['bastion_user'], username_validation)
-
     @post_load
     def make_bless_request(self, data):
         return BlessRequest(**data)
+
+    @validates('bastion_user')
+    def validate_bastion_user(self, user):
+        if USERNAME_VALIDATION_OPTION in self.context:
+            username_validation = USERNAME_VALIDATION_OPTIONS[self.context[USERNAME_VALIDATION_OPTION]]
+        else:
+            username_validation = USERNAME_VALIDATION_OPTIONS[USERNAME_VALIDATION_DEFAULT]
+        validate_user(user, username_validation)
+
+    @validates('remote_usernames')
+    def validate_remote_usernames(self, remote_usernames):
+        if REMOTE_USERNAMES_VALIDATION_OPTION in self.context:
+            username_validation = USERNAME_VALIDATION_OPTIONS[self.context[REMOTE_USERNAMES_VALIDATION_OPTION]]
+        else:
+            username_validation = USERNAME_VALIDATION_OPTIONS[REMOTE_USERNAMES_VALIDATION_DEFAULT]
+        for remote_username in remote_usernames.split(','):
+            validate_user(remote_username, username_validation)
 
 
 class BlessRequest:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'botocore',
         'cffi',
         'cryptography',
+        'enum34',
         'ipaddress',
         'marshmallow',
         'kmsauth'

--- a/tests/aws_lambda/bless-test-username-validation-disabled.cfg
+++ b/tests/aws_lambda/bless-test-username-validation-disabled.cfg
@@ -1,7 +1,0 @@
-[Bless CA]
-ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
-us-east-1_password = bogus-password-for-unit-test
-us-west-2_password = bogus-password-for-unit-tests
-[Bless Options]
-username_validation = disabled

--- a/tests/aws_lambda/bless-test-username-validation-relaxed.cfg
+++ b/tests/aws_lambda/bless-test-username-validation-relaxed.cfg
@@ -1,7 +1,0 @@
-[Bless CA]
-ca_private_key_file = ../../tests/aws_lambda/only-use-for-unit-tests.pem
-kms_key_id = alias/foo
-us-east-1_password = bogus-password-for-unit-test
-us-west-2_password = bogus-password-for-unit-tests
-[Bless Options]
-username_validation = relaxed

--- a/tests/config/test_bless_config.py
+++ b/tests/config/test_bless_config.py
@@ -3,13 +3,27 @@ import os
 
 import pytest
 
-from bless.config.bless_config import BlessConfig, BLESS_OPTIONS_SECTION, \
-    CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
-    ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
-    CERTIFICATE_VALIDITY_SEC_DEFAULT, ENTROPY_MINIMUM_BITS_DEFAULT, RANDOM_SEED_BYTES_DEFAULT, \
-    LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION, BLESS_CA_SECTION, \
-    CA_PRIVATE_KEY_FILE_OPTION, KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION, KMSAUTH_KEY_ID_OPTION, \
-    KMSAUTH_SERVICE_ID_OPTION, CERTIFICATE_EXTENSIONS_OPTION, USERNAME_VALIDATION_OPTION, USERNAME_VALIDATION_DEFAULT
+from bless.config.bless_config import BlessConfig, \
+    BLESS_OPTIONS_SECTION, \
+    CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, \
+    CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
+    ENTROPY_MINIMUM_BITS_OPTION, \
+    RANDOM_SEED_BYTES_OPTION, \
+    CERTIFICATE_VALIDITY_SEC_DEFAULT, \
+    ENTROPY_MINIMUM_BITS_DEFAULT, \
+    RANDOM_SEED_BYTES_DEFAULT, \
+    LOGGING_LEVEL_DEFAULT, \
+    LOGGING_LEVEL_OPTION, \
+    BLESS_CA_SECTION, \
+    CA_PRIVATE_KEY_FILE_OPTION, \
+    KMSAUTH_SECTION, \
+    KMSAUTH_USEKMSAUTH_OPTION, \
+    KMSAUTH_KEY_ID_OPTION, \
+    KMSAUTH_SERVICE_ID_OPTION, \
+    CERTIFICATE_EXTENSIONS_OPTION, \
+    USERNAME_VALIDATION_OPTION, \
+    USERNAME_VALIDATION_DEFAULT, \
+    REMOTE_USERNAMES_VALIDATION_OPTION
 
 
 def test_empty_config():
@@ -24,7 +38,7 @@ def test_config_no_password():
     assert 'No Region Specific And No Default Password Provided.' == e.value.message
 
     config = BlessConfig('bogus-region',
-                config_file=os.path.join(os.path.dirname(__file__), 'full-with-default.cfg'))
+                         config_file=os.path.join(os.path.dirname(__file__), 'full-with-default.cfg'))
     assert '<INSERT_DEFAULT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>' == config.getpassword()
 
 
@@ -37,6 +51,7 @@ def test_config_environment_override(monkeypatch):
         'bless_options_logging_level': 'DEBUG',
         'bless_options_certificate_extensions': 'permit-X11-forwarding',
         'bless_options_username_validation': 'debian',
+        'bless_options_remote_usernames_validation': 'useradd',
 
         'bless_ca_us-east-1_password': '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
         'bless_ca_default_password': '<INSERT_DEFAULT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
@@ -48,7 +63,7 @@ def test_config_environment_override(monkeypatch):
         'kms_auth_kmsauth_serviceid': 'bless-test',
     }
 
-    for k,v in extra_environment_variables.items():
+    for k, v in extra_environment_variables.items():
         monkeypatch.setenv(k, v)
 
     # Create an empty config, everything is set in the environment
@@ -61,6 +76,7 @@ def test_config_environment_override(monkeypatch):
     assert 'DEBUG' == config.get(BLESS_OPTIONS_SECTION, LOGGING_LEVEL_OPTION)
     assert 'permit-X11-forwarding' == config.get(BLESS_OPTIONS_SECTION, CERTIFICATE_EXTENSIONS_OPTION)
     assert 'debian' == config.get(BLESS_OPTIONS_SECTION, USERNAME_VALIDATION_OPTION)
+    assert 'useradd' == config.get(BLESS_OPTIONS_SECTION, REMOTE_USERNAMES_VALIDATION_OPTION)
 
     assert '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>' == config.getpassword()
     assert '<INSERT_YOUR_ENCRYPTED_PEM_FILE_NAME>' == config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
@@ -82,17 +98,17 @@ def test_config_environment_override(monkeypatch):
          LOGGING_LEVEL_DEFAULT,
          '<INSERT_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
          USERNAME_VALIDATION_DEFAULT
-        ),
+         ),
         ((os.path.join(os.path.dirname(__file__), 'full.cfg')), 'us-west-2',
          1, 2, 3, 'DEBUG',
          '<INSERT_US-WEST-2_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
          'debian'
-        ),
+         ),
         ((os.path.join(os.path.dirname(__file__), 'full.cfg')), 'us-east-1',
          1, 2, 3, 'DEBUG',
          '<INSERT_US-EAST-1_KMS_ENCRYPTED_BASE64_ENCODED_PEM_PASSWORD_HERE>',
          'debian'
-        )
+         )
     ])
 def test_configs(config, region, expected_cert_valid, expected_entropy_min, expected_rand_seed,
                  expected_log_level, expected_password, expected_username_validation):


### PR DESCRIPTION
Include support for configurable remote_usernames validation in addition to bastion_user.
Added an email and principal validation option, removed the relaxed option.
Updated bless_deploy_example with the new options.